### PR TITLE
Hackish fix for Linux link problems

### DIFF
--- a/cbits/HsGLURaw.c
+++ b/cbits/HsGLURaw.c
@@ -69,6 +69,11 @@ hs_GLU_getProcAddress(const char *name)
 #include <stdlib.h>
 #include <dlfcn.h>
 
+#ifndef __APPLE__
+#include <stdio.h>
+#include <GL/glu.h>
+#endif
+
 void*
 hs_GLU_getProcAddress(const char *name)
 {
@@ -80,6 +85,13 @@ hs_GLU_getProcAddress(const char *name)
     /* Get a handle for our executable. */
     handle = dlopen(NULL, RTLD_LAZY);
   }
+
+#ifndef __APPLE__
+  /* Hack to force linking of GLU on Linux */
+  FILE *bitbucket = fopen("/dev/null", "w");
+  fprintf(bitbucket, "%p\n", gluBeginCurve);
+  fclose(bitbucket); 
+#endif
 
   return handle ? dlsym(handle, name) : NULL;
 }


### PR DESCRIPTION
Hi Jason et al,

I just ran into a similar problem to Issue #1 calling `perspective`, and applying the patch found in [this SO answer](http://stackoverflow.com/a/7936492/204932) fixed the problem, although there's some unwanted output from the `printf`. 

To make the fix a bit more sustainable, I `#ifdef`ed it to not run on Macs, and sent the output to `/dev/null`. It's not ideal, certainly, but my linker-fu is apparently not up to the task of getting it to link without any undefined symbols (adding `-u gluBeginCurve` to `ld-options` seemed like it should work, but...). 

For the record, I'm running Ubuntu 11.10 with `libglu1-mesa-dev 7.11-0ubuntu3`.

Adam
